### PR TITLE
 dependencies was removed…

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP8266-WiFiSetupManager
-version=1.0.0
+version=1.0.1
 author=Borys Kotliarov
 maintainer=feedbackspring.lab@gmail.com
 sentence=WiFi configuration manager with captive portal for ESP8266
@@ -8,4 +8,3 @@ category=Communication
 url=https://github.com/BorisKotlyarov/ESP8266-WiFiSetupManager
 license=MIT
 architectures=esp8266
-depends=ESP8266WiFi, DNSServer


### PR DESCRIPTION
 cause throw error Failed to install library: 'ESP8266-WiFiSetupManager:1.0.0'. No valid dependencies solution found: dependency 'ESP8266WiFi' is not available